### PR TITLE
switch to returning a matrix of float values instead of doubles

### DIFF
--- a/src/JSON/JsonCoder.cpp
+++ b/src/JSON/JsonCoder.cpp
@@ -15,18 +15,18 @@ string JsonCoder::encodeMainMessage(mainMessage m) {
     return writer.write(root);
 }
 
-string JsonCoder::encodeMatrix(MatrixXd X) {
+string JsonCoder::encodeMatrix(const MatrixXd& X) {
     Json::Value root;
-    double r = X.rows();
-    double c = X.cols();
+    unsigned int r = X.rows();
+    unsigned int c = X.cols();
     root["r"] = r;
     root["c"] = c;
     string v = "";
-    for (int i=0; i<r; i++){
-        for (int j=0; j<c-1;j++){
-            v+=to_string(X(i,j))+",";
+    for (unsigned int i=0; i<r; i++){
+        for (unsigned int j=0; j<c-1;j++){
+            v+=to_string(float(X(i,j)))+",";
         }
-        v+=to_string(X(i,c-1))+";";
+        v+=to_string(float(X(i,c-1)))+";";
     }
     root["v"]=v;
     return writer.write(root);

--- a/src/JSON/JsonCoder.hpp
+++ b/src/JSON/JsonCoder.hpp
@@ -55,7 +55,7 @@ public:
     }
 
     string encodeMainMessage(mainMessage);
-    string encodeMatrix(MatrixXd);
+    string encodeMatrix(const MatrixXd&);
     string encodeResultPack(result_pack);
     string encodeProgressPack(progress_pack);
     string encodeTraitTreeEffectsizes(Tree*, MatrixXd);

--- a/src/Scheduler/node/Scheduler_node.cpp
+++ b/src/Scheduler/node/Scheduler_node.cpp
@@ -255,7 +255,7 @@ MatrixXd* v8toEigen(Local<v8::Array>& ar) {
 
 	for (unsigned int i=0; i<rows; i++) {
 		for (unsigned int j=0; j<cols; j++) {
-			(*mat)(i,j) = (double)Local<v8::Object>::Cast(ar->Get(i))->Get(props->Get(j))->NumberValue();
+			(*mat)(i,j) = (float)Local<v8::Object>::Cast(ar->Get(i))->Get(props->Get(j))->NumberValue();
 		}
 	}
 	return mat;


### PR DESCRIPTION
@HaohanWang , what do you think? Should reduce the size of returned matrices by about half, and I don't think the dropped digits are significant anyway.