### PR TITLE
change current Singleton to Meyers Singleton to avoid memory leak

### DIFF
--- a/src/Scheduler/BUILD
+++ b/src/Scheduler/BUILD
@@ -32,8 +32,8 @@ cc_library(
         "//Stats:FisherTest",
         "//Stats:Chi2Test",
         "//Stats:WaldTest",
-		"//Graph:NeighborSelection",
-		"//Graph:GraphicalLasso"]
+        "//Graph:NeighborSelection",
+        "//Graph:GraphicalLasso"]
 )
 
 

--- a/src/Scheduler/Scheduler.cpp
+++ b/src/Scheduler/Scheduler.cpp
@@ -45,7 +45,6 @@
 #include "Graph/NeighborSelection.hpp"
 #include "Graph/GraphicalLasso.hpp"
 #include "Scheduler/Job.hpp"
-#include "iostream"
 #else
 #include "../Algorithms/Algorithm.hpp"
 #include "../Algorithms/AlgorithmOptions.hpp"
@@ -70,13 +69,9 @@
 #include "../Graph/NeighborSelection.hpp"
 #include "../Graph/GraphicalLasso.hpp"
 #include "../Scheduler/Job.hpp"
-#include "iostream"
 #endif
 
 using namespace std;
-
-// Global static pointer used to ensure a single instance of this class.
-Scheduler* Scheduler::s_instance;
 
 
 //////////////////////////////////////////
@@ -93,13 +88,11 @@ Scheduler::Scheduler()
 }
 
 Scheduler& Scheduler::operator=(Scheduler const& s) {
-	return *Scheduler::Instance();
+    return Scheduler::Instance();
 }
 
-Scheduler* Scheduler::Instance() {	
-	if (!s_instance) {	// Singleton
-		s_instance = new Scheduler();
-	}
+Scheduler& Scheduler::Instance() {	
+	static Scheduler s_instance;
 	return s_instance;
 }
 

--- a/src/Scheduler/Scheduler.hpp
+++ b/src/Scheduler/Scheduler.hpp
@@ -73,7 +73,7 @@ public:
 	// TODO: How to know if the user owns the algorithm?
 	bool deleteJob(const job_id_t);
 
-	static Scheduler* Instance();
+	static Scheduler& Instance();
 	// This class follows the singleton pattern.
 
 protected:
@@ -123,7 +123,6 @@ private:
     FRIEND_TEST(SchedulerTest, JobIdUsed);
     #endif
 
-    static Scheduler* s_instance;   // Singleton
     const unsigned int kMaxThreads = 5;
 
     const algorithm_id_t kMaxAlgorithmId = 100;

--- a/src/Scheduler/Scheduler_Tests.cpp
+++ b/src/Scheduler/Scheduler_Tests.cpp
@@ -22,15 +22,14 @@ using namespace Eigen;
 
 class SchedulerTest : public testing::Test {
 protected:
-	virtual void SetUp() {
-		my_scheduler = Scheduler::Instance();
-		alg_opts = AlgorithmOptions_t(
-			proximal_gradient_descent,
-			{{"tolerance", "0.01"}, {"learning_rate", "0.01"}});
+    virtual void SetUp() {
+        alg_opts = AlgorithmOptions_t(
+            proximal_gradient_descent,
+            {{"tolerance", "0.01"}, {"learning_rate", "0.01"}});
 
-		model_opts = ModelOptions_t(
-			linear_regression,
-			{{"lambda", "0.01"}, {"L2_lambda", "0.01"}});
+        model_opts = ModelOptions_t(
+            linear_regression,
+            {{"lambda", "0.01"}, {"L2_lambda", "0.01"}});
 
         X = MatrixXf(10, 5);
         X << 0.8147,    0.1576,    0.6557,    0.7060,    0.4387,
@@ -55,7 +54,7 @@ protected:
         0.3692,
         0.1112;
 
-		LargeX = MatrixXf(n_patients, n_markers);
+        LargeX = MatrixXf(n_patients, n_markers);
         for (int i = 0; i < n_patients; i++) {
             for (int j = 0; j < n_markers; j++) {
                 LargeX(i,j) = rand();
@@ -67,178 +66,176 @@ protected:
                 LargeY(i,j) = rand();
             }
         }
-	}
+    }
 
-	virtual void TearDown() {}
+    virtual void TearDown() {}
 
     const int n_patients = 1000;
     const int n_markers = 1000;
     const int n_traits = 1;
-	AlgorithmOptions_t alg_opts;
+    AlgorithmOptions_t alg_opts;
     MatrixXf X;
     MatrixXf y;
     MatrixXf LargeX;
     MatrixXf LargeY;
-	ModelOptions_t model_opts;
-	Scheduler* my_scheduler;
+    ModelOptions_t model_opts;
 };
 
 
 TEST_F(SchedulerTest, Singleton) {
-	Scheduler* my_scheduler2 = Scheduler::Instance();
-	ASSERT_EQ(my_scheduler, my_scheduler2);
+	ASSERT_EQ(&(Scheduler::Instance()), &(Scheduler::Instance()));
 }
 
 
 TEST_F(SchedulerTest, getNewAlgorithmId) {
-	int alg_num1 = my_scheduler->getNewAlgorithmId();
-	EXPECT_GE(alg_num1, 0);
-	int alg_num2 = my_scheduler->getNewAlgorithmId();
-	EXPECT_GT(alg_num2, alg_num1);
+    int alg_num1 = Scheduler::Instance().getNewAlgorithmId();
+    EXPECT_GE(alg_num1, 0);
+    int alg_num2 = Scheduler::Instance().getNewAlgorithmId();
+    EXPECT_GT(alg_num2, alg_num1);
 
-	// Since we aren't actually making any algorithms, we shouldn't run out of IDs.
-	for (int i = 0; i < 1000; i++) {
-		EXPECT_GE(my_scheduler->getNewAlgorithmId(), 0);
-	}
+    // Since we aren't actually making any algorithms, we shouldn't run out of IDs.
+    for (int i = 0; i < 1000; i++) {
+        EXPECT_GE(Scheduler::Instance().getNewAlgorithmId(), 0);
+    }
 }
 
 
 TEST_F(SchedulerTest, newAlgorithm) {
-	int alg_num1 = my_scheduler->newAlgorithm(alg_opts);
-	EXPECT_GE(alg_num1, 0);
-    EXPECT_TRUE(my_scheduler->deleteAlgorithm(alg_num1));
+    int alg_num1 = Scheduler::Instance().newAlgorithm(alg_opts);
+    EXPECT_GE(alg_num1, 0);
+    EXPECT_TRUE(Scheduler::Instance().deleteAlgorithm(alg_num1));
 
-	AlgorithmOptions_t alg_opts2 = AlgorithmOptions_t(brent_search, 
+    AlgorithmOptions_t alg_opts2 = AlgorithmOptions_t(brent_search, 
         {{"tolerance", "0.01"}, {"learning_rate", "0.01"}});
-    int alg_num2 = my_scheduler->newAlgorithm(alg_opts2);
+    int alg_num2 = Scheduler::Instance().newAlgorithm(alg_opts2);
     EXPECT_GE(alg_num2, 0);
-    EXPECT_TRUE(my_scheduler->deleteAlgorithm(alg_num2));
+    EXPECT_TRUE(Scheduler::Instance().deleteAlgorithm(alg_num2));
 
     AlgorithmOptions_t alg_opts3 = AlgorithmOptions_t( grid_search, 
         {{"tolerance", "0.01"}, {"learning_rate", "0.01"}});
-    int alg_num3 = my_scheduler->newAlgorithm(alg_opts3);
+    int alg_num3 = Scheduler::Instance().newAlgorithm(alg_opts3);
     EXPECT_GE(alg_num3, 0);
-    EXPECT_TRUE(my_scheduler->deleteAlgorithm(alg_num3));
+    EXPECT_TRUE(Scheduler::Instance().deleteAlgorithm(alg_num3));
 
     AlgorithmOptions_t alg_opts4 = AlgorithmOptions_t(iterative_update,
         {{"tolerance", "0.01"}, {"learning_rate", "0.01"}});
-    int alg_num4 = my_scheduler->newAlgorithm(alg_opts4);
+    int alg_num4 = Scheduler::Instance().newAlgorithm(alg_opts4);
     EXPECT_GE(alg_num4, 0);
-    EXPECT_TRUE(my_scheduler->deleteAlgorithm(alg_num4));
+    EXPECT_TRUE(Scheduler::Instance().deleteAlgorithm(alg_num4));
     
     AlgorithmOptions_t alg_opts5 = AlgorithmOptions_t(hypo_test,
         {{"tolerance", "0.01"}, {"learning_rate", "0.01"}});
-    int alg_num5 = my_scheduler->newAlgorithm(alg_opts5);
+    int alg_num5 = Scheduler::Instance().newAlgorithm(alg_opts5);
     EXPECT_GE(alg_num5, 0);
-    EXPECT_TRUE(my_scheduler->deleteAlgorithm(alg_num5));
+    EXPECT_TRUE(Scheduler::Instance().deleteAlgorithm(alg_num5));
 }
 
 
 TEST_F(SchedulerTest, getNewModelId) {
-	int model_num1 = my_scheduler->getNewModelId();
-	EXPECT_GE(model_num1, 0);
-	int model_num2 = my_scheduler->getNewModelId();
-	EXPECT_GT(model_num2, model_num1);
+    int model_num1 = Scheduler::Instance().getNewModelId();
+    EXPECT_GE(model_num1, 0);
+    int model_num2 = Scheduler::Instance().getNewModelId();
+    EXPECT_GT(model_num2, model_num1);
 
-	// Since we aren't actually making any models, we shouldn't run out of IDs.
-	for (int i = 0; i < 1000; i++) {
-		EXPECT_GE(my_scheduler->getNewModelId(), 0);
-	}
+    // Since we aren't actually making any models, we shouldn't run out of IDs.
+    for (int i = 0; i < 1000; i++) {
+        EXPECT_GE(Scheduler::Instance().getNewModelId(), 0);
+    }
 }
 
 
 TEST_F(SchedulerTest, newModel) {
-	int model_num1 = my_scheduler->newModel(model_opts);
-	EXPECT_GE(model_num1, 0);
+    int model_num1 = Scheduler::Instance().newModel(model_opts);
+    EXPECT_GE(model_num1, 0);
 }
 
 
 TEST_F(SchedulerTest, SetX) {
-	job_id_t job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-	Eigen::MatrixXf m(2,3);
-	m << 1, 2,
-		 3, 4,
-		 5, 6;
-	EXPECT_EQ(true, my_scheduler->setX(job_id, m));
+    job_id_t job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    Eigen::MatrixXf m(2,3);
+    m << 1, 2,
+         3, 4,
+         5, 6;
+    EXPECT_EQ(true, Scheduler::Instance().setX(job_id, m));
 }
 
 
 TEST_F(SchedulerTest, SetY) {
-	job_id_t job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-	Eigen::MatrixXf m(2,3);
-	m << 1, 2,
-		 3, 4,
-		 5, 6;
-	EXPECT_EQ(true, my_scheduler->setY(job_id, m));
+    job_id_t job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    Eigen::MatrixXf m(2,3);
+    m << 1, 2,
+         3, 4,
+         5, 6;
+    EXPECT_EQ(true, Scheduler::Instance().setY(job_id, m));
 }
 
 
 TEST_F(SchedulerTest, getNewJobId) {
-	job_id_t job_id1 = my_scheduler->getNewJobId();
-	EXPECT_GT(job_id1, 0);
-	job_id_t job_id2 = my_scheduler->getNewJobId();
-	EXPECT_GT(job_id2, job_id1);
+    job_id_t job_id1 = Scheduler::Instance().getNewJobId();
+    EXPECT_GT(job_id1, 0);
+    job_id_t job_id2 = Scheduler::Instance().getNewJobId();
+    EXPECT_GT(job_id2, job_id1);
 
-	for (int i = 0; i < 1000; i++) {
-		EXPECT_GT(my_scheduler->getNewJobId(), 0);
-	}
+    for (int i = 0; i < 1000; i++) {
+        EXPECT_GT(Scheduler::Instance().getNewJobId(), 0);
+    }
 }
 
 
 TEST_F(SchedulerTest, newJob) {
-	job_id_t job_id1 = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-	ASSERT_GT(job_id1, 0);
+    job_id_t job_id1 = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_GT(job_id1, 0);
 }
 
 TEST_F(SchedulerTest, ValidAlgorithmId) {
-    ASSERT_FALSE(my_scheduler->ValidAlgorithmId(-1));
-    EXPECT_TRUE(my_scheduler->ValidAlgorithmId(my_scheduler->getNewAlgorithmId()));
-    const algorithm_id_t alg_num = my_scheduler->newAlgorithm(alg_opts);
-    ASSERT_TRUE(my_scheduler->ValidAlgorithmId(alg_num));
+    ASSERT_FALSE(Scheduler::Instance().ValidAlgorithmId(-1));
+    EXPECT_TRUE(Scheduler::Instance().ValidAlgorithmId(Scheduler::Instance().getNewAlgorithmId()));
+    const algorithm_id_t alg_num = Scheduler::Instance().newAlgorithm(alg_opts);
+    ASSERT_TRUE(Scheduler::Instance().ValidAlgorithmId(alg_num));
 }
 
 
 TEST_F(SchedulerTest, ValidModelId) {
-    ASSERT_FALSE(my_scheduler->ValidModelId(-1));
-    EXPECT_TRUE(my_scheduler->ValidModelId(my_scheduler->getNewModelId()));
-    const model_id_t model_num1 = my_scheduler->newModel(model_opts);
-    ASSERT_TRUE(my_scheduler->ValidModelId(model_num1));
+    ASSERT_FALSE(Scheduler::Instance().ValidModelId(-1));
+    EXPECT_TRUE(Scheduler::Instance().ValidModelId(Scheduler::Instance().getNewModelId()));
+    const model_id_t model_num1 = Scheduler::Instance().newModel(model_opts);
+    ASSERT_TRUE(Scheduler::Instance().ValidModelId(model_num1));
 }
 
 
 TEST_F(SchedulerTest, ValidJobId) {
-    ASSERT_FALSE(my_scheduler->ValidJobId(-1));
-    EXPECT_TRUE(my_scheduler->ValidJobId(my_scheduler->getNewJobId()));
-    const job_id_t job_id1 = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-    ASSERT_TRUE(my_scheduler->ValidJobId(job_id1));
-    my_scheduler->deleteJob(job_id1);
-    ASSERT_TRUE(my_scheduler->ValidJobId(job_id1));
+    ASSERT_FALSE(Scheduler::Instance().ValidJobId(-1));
+    EXPECT_TRUE(Scheduler::Instance().ValidJobId(Scheduler::Instance().getNewJobId()));
+    const job_id_t job_id1 = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_TRUE(Scheduler::Instance().ValidJobId(job_id1));
+    Scheduler::Instance().deleteJob(job_id1);
+    ASSERT_TRUE(Scheduler::Instance().ValidJobId(job_id1));
 }
 
 
 TEST_F(SchedulerTest, AlgorithmIdUsed) {
-	ASSERT_FALSE(my_scheduler->AlgorithmIdUsed(-1));
-	EXPECT_FALSE(my_scheduler->AlgorithmIdUsed(my_scheduler->getNewAlgorithmId()));
-	const algorithm_id_t alg_num = my_scheduler->newAlgorithm(alg_opts);
-	ASSERT_TRUE(my_scheduler->AlgorithmIdUsed(alg_num));
+    ASSERT_FALSE(Scheduler::Instance().AlgorithmIdUsed(-1));
+    EXPECT_FALSE(Scheduler::Instance().AlgorithmIdUsed(Scheduler::Instance().getNewAlgorithmId()));
+    const algorithm_id_t alg_num = Scheduler::Instance().newAlgorithm(alg_opts);
+    ASSERT_TRUE(Scheduler::Instance().AlgorithmIdUsed(alg_num));
 }
 
 
 TEST_F(SchedulerTest, ModelIdUsed) {
-	ASSERT_FALSE(my_scheduler->ModelIdUsed(-1));
-	EXPECT_FALSE(my_scheduler->ModelIdUsed(my_scheduler->getNewModelId()));
-	const model_id_t model_num1 = my_scheduler->newModel(model_opts);
-	ASSERT_TRUE(my_scheduler->ModelIdUsed(model_num1));
+    ASSERT_FALSE(Scheduler::Instance().ModelIdUsed(-1));
+    EXPECT_FALSE(Scheduler::Instance().ModelIdUsed(Scheduler::Instance().getNewModelId()));
+    const model_id_t model_num1 = Scheduler::Instance().newModel(model_opts);
+    ASSERT_TRUE(Scheduler::Instance().ModelIdUsed(model_num1));
 }
 
 
 TEST_F(SchedulerTest, JobIdUsed) {
-	ASSERT_FALSE(my_scheduler->JobIdUsed(-1));
-	EXPECT_FALSE(my_scheduler->JobIdUsed(my_scheduler->getNewJobId()));
-	const job_id_t job_id1 = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-	ASSERT_TRUE(my_scheduler->JobIdUsed(job_id1));
-	my_scheduler->deleteJob(job_id1);
-	ASSERT_FALSE(my_scheduler->JobIdUsed(job_id1));
+    ASSERT_FALSE(Scheduler::Instance().JobIdUsed(-1));
+    EXPECT_FALSE(Scheduler::Instance().JobIdUsed(Scheduler::Instance().getNewJobId()));
+    const job_id_t job_id1 = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_TRUE(Scheduler::Instance().JobIdUsed(job_id1));
+    Scheduler::Instance().deleteJob(job_id1);
+    ASSERT_FALSE(Scheduler::Instance().JobIdUsed(job_id1));
 }
 
 
@@ -247,7 +244,7 @@ void NullFunc(uv_work_t* req, int status) {};
 
 TEST_F(SchedulerTest, Train_Not_Found) {
     try {
-	   my_scheduler->startJob(-1, NullFunc);
+        Scheduler::Instance().startJob(-1, NullFunc);
     } catch (const exception& e) {
         EXPECT_STREQ("Job id must correspond to a job that has been created.", e.what());
     }
@@ -255,136 +252,136 @@ TEST_F(SchedulerTest, Train_Not_Found) {
 
 
 TEST_F(SchedulerTest, Train) {
-	job_id_t job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-	ASSERT_TRUE(my_scheduler->setX(job_id, X));
-    ASSERT_TRUE(my_scheduler->setY(job_id, y));
-	ASSERT_TRUE(my_scheduler->startJob(job_id, NullFunc));
+    job_id_t job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_TRUE(Scheduler::Instance().setX(job_id, X));
+    ASSERT_TRUE(Scheduler::Instance().setY(job_id, y));
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id, NullFunc));
 }
 
 TEST_F(SchedulerTest, CheckJobProgress) {
-    EXPECT_EQ(-1, my_scheduler->checkJobProgress(-1));	// job progress == -1 for bad ID
+    EXPECT_EQ(-1, Scheduler::Instance().checkJobProgress(-1));	// job progress == -1 for bad ID
 
     // Large Job
-    job_id_t job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-    ASSERT_TRUE(my_scheduler->setX(job_id, LargeX));
-    ASSERT_TRUE(my_scheduler->setY(job_id, LargeY));
-    ASSERT_EQ(0, my_scheduler->checkJobProgress(job_id));	// job progress == 0 before being run
-    ASSERT_TRUE(my_scheduler->startJob(job_id, NullFunc));
-    while(my_scheduler->checkJobProgress(job_id) == 0) {
+    job_id_t job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_TRUE(Scheduler::Instance().setX(job_id, LargeX));
+    ASSERT_TRUE(Scheduler::Instance().setY(job_id, LargeY));
+    ASSERT_EQ(0, Scheduler::Instance().checkJobProgress(job_id));	// job progress == 0 before being run
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id, NullFunc));
+    while(Scheduler::Instance().checkJobProgress(job_id) == 0) {
     	usleep(1);
     }
-    float progress = my_scheduler->checkJobProgress(job_id);	// 0 < job progress < 1 before end of run
+    float progress = Scheduler::Instance().checkJobProgress(job_id);	// 0 < job progress < 1 before end of run
     ASSERT_GE(progress, 0);
     ASSERT_LT(progress, 1);
-    float progress_2 = my_scheduler->checkJobProgress(job_id);	// job progress monotonically increasing
+    float progress_2 = Scheduler::Instance().checkJobProgress(job_id);	// job progress monotonically increasing
     ASSERT_GE(progress_2, progress);
-    while(my_scheduler->checkJobProgress(job_id) < 1.0) {
+    while(Scheduler::Instance().checkJobProgress(job_id) < 1.0) {
         usleep(1);
     }
-    ASSERT_EQ(1.0, my_scheduler->checkJobProgress(job_id));	// job progress == 1 after run
+    ASSERT_EQ(1.0, Scheduler::Instance().checkJobProgress(job_id));	// job progress == 1 after run
 
-	// Everything should be the same for a second run (this small job only takes 1 iteration, though).
-	job_id_t job_id2 = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-	my_scheduler->setX(job_id2, X);
-    my_scheduler->setY(job_id2, y);
-	ASSERT_TRUE(my_scheduler->startJob(job_id2, NullFunc));
+    // Everything should be the same for a second run (this small job only takes 1 iteration, though).
+    job_id_t job_id2 = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    Scheduler::Instance().setX(job_id2, X);
+    Scheduler::Instance().setY(job_id2, y);
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id2, NullFunc));
 
-	progress = my_scheduler->checkJobProgress(job_id2);
-	ASSERT_GE(progress, 0);
-	progress_2 = my_scheduler->checkJobProgress(job_id2);
-	ASSERT_GE(progress_2, progress);
+    progress = Scheduler::Instance().checkJobProgress(job_id2);
+    ASSERT_GE(progress, 0);
+    progress_2 = Scheduler::Instance().checkJobProgress(job_id2);
+    ASSERT_GE(progress_2, progress);
 
-    while(my_scheduler->checkJobProgress(job_id2) < 1.0) {
+    while(Scheduler::Instance().checkJobProgress(job_id2) < 1.0) {
         usleep(1);
     }
-    ASSERT_EQ(1.0, my_scheduler->checkJobProgress(job_id2));
+    ASSERT_EQ(1.0, Scheduler::Instance().checkJobProgress(job_id2));
 
     // Run large job again
-    job_id_t job_id3 = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
+    job_id_t job_id3 = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
     ASSERT_NE(job_id, job_id3);
-    my_scheduler->setX(job_id3, LargeX);
-    my_scheduler->setY(job_id3, LargeY);
-    ASSERT_EQ(0, my_scheduler->checkJobProgress(job_id3));
-    ASSERT_TRUE(my_scheduler->startJob(job_id3, NullFunc));
-    while(my_scheduler->checkJobProgress(job_id3) == 0) {
+    Scheduler::Instance().setX(job_id3, LargeX);
+    Scheduler::Instance().setY(job_id3, LargeY);
+    ASSERT_EQ(0, Scheduler::Instance().checkJobProgress(job_id3));
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id3, NullFunc));
+    while(Scheduler::Instance().checkJobProgress(job_id3) == 0) {
     	usleep(1);
     }
-    progress = my_scheduler->checkJobProgress(job_id3);
+    progress = Scheduler::Instance().checkJobProgress(job_id3);
     ASSERT_GE(progress, 0);
     ASSERT_LT(progress, 1);
-    progress_2 = my_scheduler->checkJobProgress(job_id3);
+    progress_2 = Scheduler::Instance().checkJobProgress(job_id3);
     ASSERT_GE(progress_2, progress);
-    while(my_scheduler->checkJobProgress(job_id3) < 1.0) {
+    while(Scheduler::Instance().checkJobProgress(job_id3) < 1.0) {
         usleep(1);
     }
-    ASSERT_EQ(1.0, my_scheduler->checkJobProgress(job_id3));
+    ASSERT_EQ(1.0, Scheduler::Instance().checkJobProgress(job_id3));
 
-	ASSERT_TRUE(my_scheduler->deleteJob(job_id3));
-	ASSERT_EQ(my_scheduler->checkJobProgress(job_id3), -1);	// job progress == -1 after being deleted
+    ASSERT_TRUE(Scheduler::Instance().deleteJob(job_id3));
+    ASSERT_EQ(Scheduler::Instance().checkJobProgress(job_id3), -1);	// job progress == -1 after being deleted
 }
 
 
 TEST_F(SchedulerTest, DeleteJob) {
-    ASSERT_FALSE(my_scheduler->deleteJob(-1));  // can't delete non-existent job
+    ASSERT_FALSE(Scheduler::Instance().deleteJob(-1));  // can't delete non-existent job
 
     // Short job - delete after finishing
-    job_id_t job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-    my_scheduler->setX(job_id, X);
-    my_scheduler->setY(job_id, y);
-    ASSERT_TRUE(my_scheduler->startJob(job_id, NullFunc));
+    job_id_t job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    Scheduler::Instance().setX(job_id, X);
+    Scheduler::Instance().setY(job_id, y);
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id, NullFunc));
 
-    float progress = my_scheduler->checkJobProgress(job_id);
+    float progress = Scheduler::Instance().checkJobProgress(job_id);
     ASSERT_GE(progress, 0);
-    float progress_2 = my_scheduler->checkJobProgress(job_id);
+    float progress_2 = Scheduler::Instance().checkJobProgress(job_id);
     ASSERT_GE(progress_2, progress);
-    while(my_scheduler->checkJobProgress(job_id) < 1.0) {
+    while(Scheduler::Instance().checkJobProgress(job_id) < 1.0) {
         usleep(1);
     }
-    ASSERT_EQ(1.0, my_scheduler->checkJobProgress(job_id));
-    ASSERT_TRUE(my_scheduler->deleteJob(job_id));
-    ASSERT_FALSE(my_scheduler->deleteJob(job_id));  // can't delete job twice
+    ASSERT_EQ(1.0, Scheduler::Instance().checkJobProgress(job_id));
+    ASSERT_TRUE(Scheduler::Instance().deleteJob(job_id));
+    ASSERT_FALSE(Scheduler::Instance().deleteJob(job_id));  // can't delete job twice
 
     // Large job - delete while it is running
-    job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-    ASSERT_TRUE(my_scheduler->setX(job_id, LargeX));
-    ASSERT_TRUE(my_scheduler->setY(job_id, LargeY));
-    ASSERT_EQ(0, my_scheduler->checkJobProgress(job_id));   // job progress == 0 before being run
-    ASSERT_TRUE(my_scheduler->startJob(job_id, NullFunc));
-    while(my_scheduler->checkJobProgress(job_id) == 0) {
+    job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_TRUE(Scheduler::Instance().setX(job_id, LargeX));
+    ASSERT_TRUE(Scheduler::Instance().setY(job_id, LargeY));
+    ASSERT_EQ(0, Scheduler::Instance().checkJobProgress(job_id));   // job progress == 0 before being run
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id, NullFunc));
+    while(Scheduler::Instance().checkJobProgress(job_id) == 0) {
         usleep(1);
     }
-    progress = my_scheduler->checkJobProgress(job_id);   // 0 < job progress < 1 before end of run
+    progress = Scheduler::Instance().checkJobProgress(job_id);   // 0 < job progress < 1 before end of run
     ASSERT_GE(progress, 0);
     ASSERT_LT(progress, 1);
-    ASSERT_TRUE(my_scheduler->deleteJob(job_id));   // should be able to safely delete a job while it's running (it gets cancelled)    
-    ASSERT_EQ(-1, my_scheduler->checkJobProgress(job_id)); // deleted job has progress = -1
+    ASSERT_TRUE(Scheduler::Instance().deleteJob(job_id));   // should be able to safely delete a job while it's running (it gets cancelled)    
+    ASSERT_EQ(-1, Scheduler::Instance().checkJobProgress(job_id)); // deleted job has progress = -1
 
     // Should be able to do it all again.
-    job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-    ASSERT_TRUE(my_scheduler->setX(job_id, LargeX));
-    ASSERT_TRUE(my_scheduler->setY(job_id, LargeY));
-    ASSERT_EQ(0, my_scheduler->checkJobProgress(job_id));   // job progress == 0 before being run
-    ASSERT_TRUE(my_scheduler->startJob(job_id, NullFunc));
-    while(my_scheduler->checkJobProgress(job_id) == 0) {
+    job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    ASSERT_TRUE(Scheduler::Instance().setX(job_id, LargeX));
+    ASSERT_TRUE(Scheduler::Instance().setY(job_id, LargeY));
+    ASSERT_EQ(0, Scheduler::Instance().checkJobProgress(job_id));   // job progress == 0 before being run
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id, NullFunc));
+    while(Scheduler::Instance().checkJobProgress(job_id) == 0) {
         usleep(1);
     }
-    progress = my_scheduler->checkJobProgress(job_id);   // 0 < job progress < 1 before end of run
+    progress = Scheduler::Instance().checkJobProgress(job_id);   // 0 < job progress < 1 before end of run
     ASSERT_GE(progress, 0);
     ASSERT_LT(progress, 1);
-    ASSERT_TRUE(my_scheduler->deleteJob(job_id));   // should be able to safely delete a job while it's running (it gets cancelled)    
-    ASSERT_EQ(-1, my_scheduler->checkJobProgress(job_id)); // deleted job has progress = -1
+    ASSERT_TRUE(Scheduler::Instance().deleteJob(job_id));   // should be able to safely delete a job while it's running (it gets cancelled)    
+    ASSERT_EQ(-1, Scheduler::Instance().checkJobProgress(job_id)); // deleted job has progress = -1
 }
 
 
 TEST_F(SchedulerTest, GetJobResult) {
-    job_id_t job_id = my_scheduler->newJob(JobOptions_t(alg_opts, model_opts));
-    my_scheduler->setX(job_id, X);
-    my_scheduler->setY(job_id, y);    
-    ASSERT_TRUE(my_scheduler->startJob(job_id, NullFunc));
+    job_id_t job_id = Scheduler::Instance().newJob(JobOptions_t(alg_opts, model_opts));
+    Scheduler::Instance().setX(job_id, X);
+    Scheduler::Instance().setY(job_id, y);    
+    ASSERT_TRUE(Scheduler::Instance().startJob(job_id, NullFunc));
 
-    MatrixXf results = my_scheduler->getJobResult(job_id);
-    while (my_scheduler->checkJobProgress(job_id) < 1.0) {
+    MatrixXf results = Scheduler::Instance().getJobResult(job_id);
+    while (Scheduler::Instance().checkJobProgress(job_id) < 1.0) {
         usleep(1);
     }
-    results = my_scheduler->getJobResult(job_id);
+    results = Scheduler::Instance().getJobResult(job_id);
 }


### PR DESCRIPTION
The current implementation of Singleton requires users to manually delete the instance and there is no such code to do that so there would be memory leaks. Actually, in C++11, Meyers Singleton is a simpler and more powerful way to do that:
https://github.com/blengerich/GenAMap/blob/valgrind_check/src/Scheduler/Scheduler.cpp#L94

Some explanations about Meyers Singleton: http://stackoverflow.com/a/17713799

This modification can eliminate most memory leaks in the scheduler. There are still some other leaks (128 bytes) but it seems that they come from uv_queue_work(). 